### PR TITLE
Run callbacks for all transitions

### DIFF
--- a/lib/state_machines/integrations/mongoid.rb
+++ b/lib/state_machines/integrations/mongoid.rb
@@ -360,6 +360,10 @@ module StateMachines
                 self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
               end
 
+              def update_document(*)
+                self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
+              end
+
               def upsert(*)
                 self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
               end

--- a/lib/state_machines/integrations/mongoid/version.rb
+++ b/lib/state_machines/integrations/mongoid/version.rb
@@ -1,7 +1,7 @@
 module StateMachines
   module Integrations
     module Mongoid
-      VERSION = '0.1.0'
+      VERSION = '0.1.1'
     end
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -14,7 +14,7 @@ class IntegrationTest < BaseTestCase
   end
 
   def test_should_have_defaults
-    assert_equal({:action => :save}, StateMachines::Integrations::Mongoid.defaults)
+    assert_equal({:action => :save, :use_transactions => false}, StateMachines::Integrations::Mongoid.defaults)
   end
 
   def test_should_have_a_locale_path

--- a/test/machine_with_multiple_callbacks_test.rb
+++ b/test/machine_with_multiple_callbacks_test.rb
@@ -1,0 +1,37 @@
+require_relative 'test_helper'
+
+class MachineWithMultipleTransitionsTest < BaseTestCase
+  def setup
+    @callbacks = []
+
+    @model = new_model
+    @machine = StateMachines::Machine.new(@model)
+    @machine.event :ignite do
+      transition :parked => :idling
+    end
+    @machine.event :shift_up do
+      transition :idling => :first_gear
+    end
+    @record = @model.new(state: 'parked')
+  end
+
+  def test_should_run_before_callback_for_every_transition
+    before_count = 0
+    @machine.before_transition { before_count += 1 }
+    
+    @record.ignite
+    assert_equal 1, before_count
+    @record.shift_up
+    assert_equal 2, before_count
+  end
+
+  def test_should_run_after_callback_for_every_transition
+    after_count = 0
+    @machine.after_transition { after_count += 1 }
+
+    @record.ignite
+    assert_equal 1, after_count
+    @record.shift_up
+    assert_equal 2, after_count
+  end
+end


### PR DESCRIPTION
I found one more bug which causes after callbacks to only run once even for multiple transitions. And I fixed the broken integration test too.

Again I would be very happy if you can release the updated GEM. 

Sorry to not catch that bug earlier and thanks a lot!
