### PR TITLE
Use default client instead of create a new client when running tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,8 +18,7 @@ class BaseTestCase < Minitest::Test
 
   def teardown
     if @table_names
-      client = Mongo::Client.new(['127.0.0.1:27017'])
-      db = Mongo::Database.new(client, :test)
+      db = Mongoid::Clients.default
       db.collections.each {|c| c.drop if @table_names.include?(c.name)}
     end
   end


### PR DESCRIPTION
When I run the tests, I get following errors after a while:

```
Mongo::Error::NoServerAvailable:         Mongo::Error::NoServerAvailable: No server is available matching preference: #<Mongo::ServerSelector::Primary:0x007fe8fa5593e0 @options={"mode"=>:primary, "database"=>"admin"}, @tag_sets=[], @server_selection_timeout=30>
D, [2015-11-17T18:00:13.977278 #32569] DEBUG -- : MONGODB | Adding 127.0.0.1:27017 to the cluster.
D, [2015-11-17T18:00:13.980724 #32569] DEBUG -- : MONGODB | IOError
D, [2015-11-17T18:00:14.480547 #32569] DEBUG -- : MONGODB | IOError
```

I think the problem is because a new client is created every time in `teardown`.

This PR modifies `BaseTestCase` to use default client instead of create a new client when running tests.
