### PR TITLE
Fix "missing attribute: state" when state attribute is not included in the query

### DIFF
--- a/lib/state_machines/integrations/mongoid.rb
+++ b/lib/state_machines/integrations/mongoid.rb
@@ -334,7 +334,7 @@ module StateMachines
               defaults = {}
               self.class.state_machines.initialize_states(self, :static => :force, :dynamic => false, :to => defaults)
               defaults.each do |attr, value|
-                send(:"\#{attr}=", value) unless attributes.include?(attr)
+                send(:"\#{attr}=", value) unless has_attribute?(attr) || attribute_missing?(attr)
               end
               super
             end

--- a/test/machine_with_limited_fields_test.rb
+++ b/test/machine_with_limited_fields_test.rb
@@ -1,0 +1,26 @@
+require_relative 'test_helper'
+
+class MachineWithLimitedFieldsTest < BaseTestCase
+  def setup
+    @model = new_model
+    @machine = StateMachines::Machine.new(@model, :initial => :parked)
+    @machine.state :idling
+
+    @record = @model.create
+  end
+
+  def test_should_not_set_value_when_exclude_field_in_query
+    record = @model.where(id: @record.id).only(:_id).first
+    assert_equal ["_id"], record.attributes.keys
+  end
+
+  def test_should_set_value_when_include_field_in_query
+    record = @model.where(id: @record.id).only(:_id, :state).first
+    assert_equal "parked", record.state
+  end
+
+  def test_should_fail_if_access_when_exclude_field_in_query
+    record = @model.where(id: @record.id).only(:_id).first
+    assert_raises(ActiveModel::MissingAttributeError) { record.state }
+  end
+end


### PR DESCRIPTION
When limiting the fields returned from the database the error is raised:

```
[1] pry(main)> i = Model.all.only(:_id).first
ActiveModel::MissingAttributeError: Missing attribute: 'state'.
from /Users/sergio/.rvm/gems/ruby-2.2.0/gems/mongoid-4.0.2/lib/mongoid/attributes.rb:97:in `read_attribute'
```

This PR excludes state initialization when the attribute is not included in the query.
